### PR TITLE
Moving delegate callback for `isReadyToBeginExecutingWithRemainingArgume...

### DIFF
--- a/CLIKit/CLIApplication.m
+++ b/CLIKit/CLIApplication.m
@@ -13,6 +13,7 @@
 @interface CLIApplicationOptionParserDelegate : NSObject <CLIOptionParserDelegate>
 
 @property (weak, readonly, nonatomic) CLIApplication* application;
+@property (copy, nonatomic) NSArray *remainingArguments;
 
 - (instancetype)initWithApplication: (CLIApplication*)application;
 
@@ -38,9 +39,7 @@
 }
 
 - (void)optionParser: (CLIOptionParser*)parser didEncounterNonOptionArguments: (NSArray*)remainingArguments {
-    if (nil != self.application.delegate) {
-        [self.application.delegate application: self.application isReadyToBeginExecutingWithRemainingArguments: remainingArguments];
-    }
+    self.remainingArguments = remainingArguments;
 }
 
 @end
@@ -108,7 +107,12 @@
             
             [self.optionParser parseCommandLineArguments: argsFromMain count: argumentCount optionsToRecognize: self.recognizedOptions error: &err];
             
-            if (nil != err) {
+            if (nil == err) {
+                if ([self.delegate respondsToSelector:@selector(application:isReadyToBeginExecutingWithRemainingArguments:)]) {
+                    [self.delegate application:self isReadyToBeginExecutingWithRemainingArguments:self.optionParserDelegate.remainingArguments];
+                }
+
+            } else {
                 [self.delegate application: self didFailOptionParsingWithError: err];
             }
         }


### PR DESCRIPTION
This is a possible fix for (one aspect of) https://github.com/umjames/CLIKit/issues/2

By capturing the `remainingArguments` from the `optionParser: didEncounterNonOptionArguments:` delegate method in our delegate implementation and not directly calling the application.delegate, and then using these remaining arguments in `runWithCommandlineArguments:` to call the application.delegate `application:isReadyToBeginExecutingWithRemainingArguments:` we gain the ability to properly call `application: isReadyToBeginExecutingWithRemainingArguments:` under the circumstances when no non-option arguments are specified.

The only thing about this fix I'm not 100% happy with is that we are relying on our own `CLIApplicationOptionParserDelegate` implementation to capture the remaining arguments from the parser, which means we must directly call `self.optionParserDelegate.remainingArguments` to get the arguments. This means that as opposed to having a layer of abstraction we are now tied to the `CLIApplicationOptionParserDelegate` implementation.
