### PR TITLE
Fixing static analyzer warning

### DIFF
--- a/CLIKit/CLIOptionParser.m
+++ b/CLIKit/CLIOptionParser.m
@@ -163,7 +163,7 @@ NSString* const CLIMultipleErrorsKey = @"CLIMultipleErrorsKey";
 }
 
 - (void)processMissingRequiredArgumentForOption: (CLIOption*)option {
-    NSError* error = [NSError errorWithDomain: CLIKitErrorDomain code: kCLIMissingRequiredArgument userInfo: @{ NSLocalizedDescriptionKey: [NSString stringWithFormat: @"option %@ is missing a required argument", option.optionName], CLIOptionNameKey: option.optionName }];
+    NSError* error = [NSError errorWithDomain: CLIKitErrorDomain code: kCLIMissingRequiredArgument userInfo: @{ NSLocalizedDescriptionKey: [NSString stringWithFormat: @"option %@ is missing a required argument", option.optionName], CLIOptionNameKey: option.optionName ?: [NSNull null] }];
     
     [self.errorCollector addError: error];
     


### PR DESCRIPTION
Corrects a potential issue where a `nil` value could be added to the userInfo dictionary.
